### PR TITLE
Add camera backend and tests to utils/camera.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Database file
+# Database and config files
 *.db
+config.json
 
 # Cache files
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ numpy
 argon2-cffi
 xhtml2pdf
 jinja2
+opencv-python==4.13.0.92
 pytest # dev-only dependency

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,91 @@
+from unittest.mock import patch, MagicMock, mock_open
+from utils.camera import find_available_cameras, save_camera_preference, load_camera_preference, \
+    validate_camera_preference, capture_frame
+
+
+def test_find_available_cameras_success():
+    with patch("utils.camera.cv2.VideoCapture") as mock_cap:
+        mock_instance = MagicMock()
+        mock_cap.return_value = mock_instance
+        mock_instance.isOpened.return_value = True
+        result = find_available_cameras()
+        assert result == [0, 1, 2]
+
+def test_find_available_cameras_success_skipped_index():
+    with patch("utils.camera.cv2.VideoCapture") as mock_cap:
+        mock_instance = MagicMock()
+        mock_cap.return_value = mock_instance
+        mock_instance.isOpened.side_effect = [True, False, True]
+        result = find_available_cameras()
+        assert result == [0, 2]
+
+def test_find_available_cameras_no_camera():
+    with patch("utils.camera.cv2.VideoCapture") as mock_cap:
+        mock_instance = MagicMock()
+        mock_cap.return_value = mock_instance
+        mock_instance.isOpened.return_value = False
+        result = find_available_cameras()
+        assert result == []
+
+def test_save_camera_preference_success():
+    with patch("builtins.open", mock_open()):
+        result = save_camera_preference(0)
+        assert result == True
+
+def test_save_camera_preference_failure():
+    with patch("builtins.open") as mock_file:
+        mock_file.side_effect = Exception
+        result = save_camera_preference(0)
+        assert result == False
+
+def test_load_camera_preference_success():
+    with patch("builtins.open", mock_open(read_data='{"preferred_camera_index": 1}')):
+        result = load_camera_preference()
+        assert result == 1
+
+def test_load_camera_preference_failure():
+    with patch("builtins.open") as mock_file:
+        mock_file.side_effect = Exception
+        result = load_camera_preference()
+        assert result is None
+
+def test_validate_camera_preference_success():
+    preferred_camera_index = 0
+    cameras = [0, 1]
+    result = validate_camera_preference(preferred_camera_index, cameras)
+    assert result == preferred_camera_index
+
+def test_validate_camera_preference_failure():
+    preferred_camera_index = 1
+    cameras = [0]
+    result = validate_camera_preference(preferred_camera_index, cameras)
+    assert result is None
+
+def test_validate_camera_preference_none():
+    preferred_camera_index = None
+    cameras = [0]
+    result = validate_camera_preference(preferred_camera_index, cameras)
+    assert result is None
+
+def test_validate_camera_preference_empty_list():
+    preferred_camera_index = 0
+    cameras = []
+    result = validate_camera_preference(preferred_camera_index, cameras)
+    assert result is None
+
+def test_capture_frame_success():
+    with patch("utils.camera.cv2.VideoCapture") as mock_cap:
+        mock_instance = MagicMock()
+        mock_cap.return_value = mock_instance
+        mock_instance.read.return_value = (True, MagicMock())
+        result = capture_frame(0)
+        assert result is not None
+
+def test_capture_frame_failure():
+    with patch("utils.camera.cv2.VideoCapture") as mock_cap:
+        mock_instance = MagicMock()
+        mock_cap.return_value = mock_instance
+        mock_instance.read.return_value = (False, None)
+        result = capture_frame(0)
+        assert result is None
+

--- a/utils/camera.py
+++ b/utils/camera.py
@@ -1,0 +1,75 @@
+import cv2
+import json
+import numpy as np
+
+CONFIG_PATH = "config.json"
+
+def find_available_cameras() -> list[int]:
+    """
+    Finds cameras available on device and returns them as a list of integers.
+    :return: List of available cameras.
+    """
+    cameras = []
+    for i in range(3):
+        cap = cv2.VideoCapture(i)
+        if cap.isOpened():
+            cameras.append(i)
+            cap.release()
+    return cameras
+
+def save_camera_preference(camera_index: int) -> bool:
+    """
+    Takes a camera index and saves it to JSON config file.
+    :param camera_index: The index of the camera to save. 
+    :return: True if preference successfully saved to config file, False otherwise.
+    """
+    camera = {"preferred_camera_index": camera_index}
+    try:
+        with open("config.json", "w") as file:
+            json.dump(camera, file)
+        return True
+    except Exception:
+        return False
+
+def load_camera_preference() -> int | None:
+    """
+    Loads index of preferred camera from config file. Returns None if preference was not found.
+    :return: Index of preferred camera.
+    """
+    try:
+        with open("config.json", "r") as file:
+            config_file = json.load(file)
+            return config_file["preferred_camera_index"]
+    except Exception:
+        return None
+
+def validate_camera_preference(preferred_camera_index: int | None, available_cameras: list[int]) -> int | None:
+    """
+    Checks list of available cameras for preferred camera index and returns it. If preferred camera is not available or no preferred camera is selected, returns None.
+    :param preferred_camera_index: The index of the preferred camera to validate.
+    :param available_cameras: List of available cameras.
+    :return: Index of preferred camera if available, None otherwise.
+    """
+    if preferred_camera_index in available_cameras:
+        return preferred_camera_index
+    else:
+        return None
+
+def capture_frame(camera: int) -> np.ndarray | None:
+    """
+    Captures frame from camera and returns it.
+    :param camera: Index of camera to use for capture.
+    :return: Frame as numpy array or None if no frame was captured.
+    """
+    try:
+        cap = cv2.VideoCapture(camera)
+        ret, frame = cap.read()
+        cap.release()
+
+        if ret:
+            return frame
+        else:
+            return None
+    except Exception:
+        return None
+


### PR DESCRIPTION
## Summary
Adds camera backend functions to `utils/camera.py` as groundwork for the webcam scanning feature. No UI changes. Unit testing for all new functions added to tests/test_camera.py.

## Changes
- Added `utils/camera.py` with the following functions:
  - `find_available_cameras()`: checks indices 0 through 2 and returns a list of indices where a camera was found
  - `save_camera_preference()`: writes the preferred camera index to `config.json`
  - `load_camera_preference()`: reads the saved camera index from `config.json`
  - `validate_camera_preference()`: checks whether the saved preference is in the list of currently available cameras
  - `capture_frame()`: returns a frame as a NumPy array
- Added `tests/test_camera.py` with full test coverage for all functions using mocked OpenCV and file operations
- Updated `requirements.txt` with `opencv-python==4.13.0.92`
- Added `config.json` to `.gitignore`

## Notes
- OpenCV prints backend warnings but from what I can tell these are expected. There is a way to suppress them but it would also suppress real errors so I have not included code to suppress them for now.
- Camera preference is saved to `config.json` in the project root. This is added to `.gitignore`.
- All tests are mocked and do not require real hardware so they should run in CircleCI.