### PR TITLE
Store med fields on administration_log for reporting and history log

### DIFF
--- a/database/db_connection.py
+++ b/database/db_connection.py
@@ -67,10 +67,16 @@ def create_tables(conn: sqlite3.Connection | None = None) -> None:
                 log_id INTEGER NOT NULL PRIMARY KEY,
                 user_id INTEGER NOT NULL REFERENCES users(user_id),
                 medication_id INTEGER NOT NULL REFERENCES medications(medication_id),
+                medication_name TEXT,
+                dosage TEXT,
+                route TEXT,
+                frequency TEXT,
+                special_instructions TEXT,
                 date_taken TEXT NOT NULL,
                 time_taken TEXT NOT NULL,
                 status INTEGER NOT NULL,
                 notes TEXT
+
             )
         '''
         cursor.execute(create_administration_log)

--- a/inject_test.py
+++ b/inject_test.py
@@ -8,8 +8,8 @@ try:
     # Use user_id as the column name, and 1 as the value for the test patient
     cursor.execute('''
         INSERT INTO administration_log 
-        (user_id, medication_id, date_taken, time_taken, status, notes) 
-        VALUES (1, 1, '2026-04-16', 'Morning', 0, 'Missed dose test')
+        (user_id, medication_id, medication_name, dosage, route, frequency, special_instructions, date_taken, time_taken, status, notes) 
+        VALUES (1, 1, 'Test Med', '100mg', 'oral', 'Once daily', '', '2026-04-16', 'Morning', 0, 'Missed dose test')
     ''')
     conn.commit()
     print("✅ Successfully injected missed dose into the database!")

--- a/services/administration_log.py
+++ b/services/administration_log.py
@@ -14,10 +14,17 @@ def log_medication_taken(user_id, med_id, conn: sqlite3.Connection | None = None
         conn = get_connection()
     with conn:
         cursor = conn.cursor()
+        # Get the current med fields so we can preserve them on the administration log table for reporting
+        medication_name, dosage, route, frequency, special_instructions = cursor.execute('''
+            SELECT medication_name, dosage, route, frequency, special_instructions
+            FROM medications
+            WHERE medication_id = ?
+            ''', (med_id,)).fetchone()
+
         cursor.execute('''
-            INSERT INTO administration_log (user_id, medication_id, date_taken, time_taken, status, notes) 
-            VALUES (?, ?, ?, ?, 1, '')
-        ''', (user_id, med_id, date_taken, time_taken))
+            INSERT INTO administration_log (user_id, medication_id, medication_name, dosage, route, frequency, special_instructions, date_taken, time_taken, status, notes) 
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, '')
+        ''', (user_id, med_id, medication_name, dosage, route, frequency, special_instructions, date_taken, time_taken))
         conn.commit()
 
 # ADDED BY NC: Undo marking a medication as taken

--- a/services/medication.py
+++ b/services/medication.py
@@ -111,7 +111,7 @@ def get_medications_for_management(user_id, conn: sqlite3.Connection | None = No
         rows = cursor.fetchall()
         return [dict(zip(["medication_id", "name", "dosage", "route", "frequency", "scheduled_time", "prescriber", "special_instructions"], row)) for row in rows]
 
-def update_medication(medication_id, medication_name, dosage, route, frequency, scheduled_time, conn: sqlite3.Connection | None = None):
+def update_medication(medication_id, medication_name, dosage, route, frequency, scheduled_time, special_instructions, conn: sqlite3.Connection | None = None):
     """
     Update an exisitng medication record.
 
@@ -123,7 +123,7 @@ def update_medication(medication_id, medication_name, dosage, route, frequency, 
         cursor = conn.cursor()
         cursor.execute('''
             UPDATE medications
-            SET medication_name=?, dosage=?, route=?, frequency=?, scheduled_time=?
+            SET medication_name=?, dosage=?, route=?, frequency=?, scheduled_time=?, special_instructions=?
             WHERE medication_id=?
-        ''', (medication_name, dosage, route, frequency, scheduled_time, medication_id))
+        ''', (medication_name, dosage, route, frequency, scheduled_time, special_instructions, medication_id))
         conn.commit()

--- a/services/reports.py
+++ b/services/reports.py
@@ -20,13 +20,12 @@ def get_medication_history(user_id, start_date=None, end_date=None, conn=None):
         
     with conn:
         cursor = conn.cursor()
-        # Join the logs with the medications table to get names and dosages
+        # Read admin log so report reflects med info taken at time of each dose
         cursor.execute('''
-            SELECT m.medication_name, m.dosage, a.date_taken, a.time_taken, a.status, m.special_instructions
-            FROM administration_log a
-            JOIN medications m ON a.medication_id = m.medication_id
-            WHERE a.user_id = ? AND a.date_taken BETWEEN ? AND ?
-            ORDER BY a.date_taken DESC, a.time_taken DESC
+            SELECT medication_name, dosage, date_taken, time_taken, status, special_instructions
+            FROM administration_log
+            WHERE user_id = ? AND date_taken BETWEEN ? AND ?
+            ORDER BY date_taken DESC, time_taken DESC
         ''', (user_id, start_date, end_date))
         
         # Package rows into dicts for templating

--- a/tests/test_administration_log.py
+++ b/tests/test_administration_log.py
@@ -1,6 +1,7 @@
 from services.administration_log import log_medication_taken, undo_medication_taken
-from services.medication import add_medication
+from services.medication import add_medication, update_medication
 from services.user import create_new_user, get_user_id
+from services.reports import get_medication_history
 
 
 def test_log_medication_taken_success(test_db):
@@ -59,3 +60,24 @@ def test_undo_medication_taken_no_log_entry(test_db):
     add_medication(test_id, 'Vitamin C', '500 mg', 'oral', 'daily', '08:00', conn=test_db)
     result = undo_medication_taken(test_id, 1, conn=test_db)
     assert result == False
+
+def test_log_entry_not_overwritten_when_medication_changes(test_db):
+    user_data = {
+        'username': 'testuser',
+        'password': 'TestPass123',
+        'first_name': 'Trisha',
+        'last_name': 'Elric',
+        'date_of_birth': '1990-01-01'
+    }
+    create_new_user(user_data, conn = test_db)
+    test_username = user_data['username']
+    test_id = get_user_id(test_username, conn = test_db)
+
+    add_medication(test_id, 'Vitamin C', '500 mg', 'oral', 'daily', '08:00', conn = test_db)
+    log_medication_taken(test_id, 1, conn = test_db)
+
+    update_medication(1, 'Vitamin C', '1000 mg', 'oral', 'daily', '08:00', conn = test_db)
+
+    logs, start_date, end_date = get_medication_history(test_id, conn = test_db)
+    assert logs[0]['dosage'] == '500 mg'
+

--- a/tests/test_administration_log.py
+++ b/tests/test_administration_log.py
@@ -76,7 +76,7 @@ def test_log_entry_not_overwritten_when_medication_changes(test_db):
     add_medication(test_id, 'Vitamin C', '500 mg', 'oral', 'daily', '08:00', conn = test_db)
     log_medication_taken(test_id, 1, conn = test_db)
 
-    update_medication(1, 'Vitamin C', '1000 mg', 'oral', 'daily', '08:00', conn = test_db)
+    update_medication(1, 'Vitamin C', '1000 mg', 'oral', 'daily', '08:00', special_instructions='', conn = test_db)
 
     logs, start_date, end_date = get_medication_history(test_id, conn = test_db)
     assert logs[0]['dosage'] == '500 mg'

--- a/tests/test_medications.py
+++ b/tests/test_medications.py
@@ -111,13 +111,13 @@ def test_update_medication(test_db):
         'password': 'TestPass123',
         'first_name': 'Magi',
         'last_name': 'Karp',
-        'date_of_birth': '1985-11-03'
+        'date_of_birth': '1985-11-03',
     }
     test_username = user_data['username']
     create_new_user(user_data, conn = test_db)
     test_id = get_user_id(test_username, conn = test_db)
-    add_medication(test_id, "Lisinopril", "10 mg", "Oral", "Once Daily", "09:00 AM", conn = test_db)
-    add_medication(test_id, "Aspirin", "81 mg", "Oral", "Once Daily", "08:00 AM", conn = test_db)
+    add_medication(test_id, "Lisinopril", "10 mg", "Oral", "Once Daily", "09:00 AM", special_instructions="take daily bp", conn = test_db)
+    add_medication(test_id, "Aspirin", "81 mg", "Oral", "Once Daily", "08:00 AM", special_instructions="take with full glass of water", conn = test_db)
 
     # User's medications before update
     before = get_medications_for_management(test_id, conn = test_db)
@@ -126,13 +126,44 @@ def test_update_medication(test_db):
     med_id = before[0]['medication_id']
 
     # Edit Aspirin info and check for successful update
-    update_medication(med_id, "Aspirin Low Dose", "81 mg chewable", "Oral with food", "Twice daily", "Morning,Evening", conn = test_db)
+    update_medication(med_id, "Aspirin Low Dose", "81 mg chewable", "Oral with food", "Twice daily", "Morning,Evening", special_instructions="take with food", conn = test_db)
     after = get_medications_for_management(test_id, conn = test_db)
     assert after[0]['name'] == 'Aspirin Low Dose'
     assert after[0]['dosage'] == '81 mg chewable'
     assert after[0]['route'] == 'Oral with food'
     assert after[0]['frequency'] == 'Twice daily'
     assert after[0]['scheduled_time'] == 'Morning,Evening'
+    assert after[0]['special_instructions'] == 'take with food'
+
+def test_update_medication_special_instructions_empty(test_db):
+    user_data = {
+        'username': 'testuser',
+        'password': 'TestPass123',
+        'first_name': 'Vulpix',
+        'last_name': 'Alolan',
+        'date_of_birth': '1985-11-03',
+    }
+    test_username = user_data['username']
+    create_new_user(user_data, conn = test_db)
+    test_id = get_user_id(test_username, conn = test_db)
+    add_medication(test_id, "Lisinopril", "10 mg", "Oral", "Once Daily", "09:00 AM", special_instructions="take daily bp", conn = test_db)
+    add_medication(test_id, "Aspirin", "81 mg", "Oral", "Once Daily", "08:00 AM", special_instructions="take with full glass of water", conn = test_db)
+
+    # User's medications before update
+    before = get_medications_for_management(test_id, conn = test_db)
+    assert len(before) == 2
+    assert before[0]['name'] == 'Aspirin'
+    med_id = before[0]['medication_id']
+
+    # Edit Aspirin info and check for successful update
+    update_medication(med_id, "Aspirin Low Dose", "81 mg chewable", "Oral with food", "Twice daily", "Morning,Evening", special_instructions="", conn = test_db)
+    after = get_medications_for_management(test_id, conn = test_db)
+    assert after[0]['name'] == 'Aspirin Low Dose'
+    assert after[0]['dosage'] == '81 mg chewable'
+    assert after[0]['route'] == 'Oral with food'
+    assert after[0]['frequency'] == 'Twice daily'
+    assert after[0]['scheduled_time'] == 'Morning,Evening'
+    assert after[0]['special_instructions'] == ''
 
 def test_check_duplicate_medication(test_db):
     """Test that the duplicate checker accurately identifies active matching names."""

--- a/ui/manage_medication.py
+++ b/ui/manage_medication.py
@@ -292,7 +292,7 @@ class ManageMedicationScreen(QWidget):
         # If in editing mode update the selected medication
         else:
             update_medication(
-                self.editing_medication_id, medication_name, strength, directions, frequency, timing
+                self.editing_medication_id, medication_name, strength, directions, frequency, timing, notes
             )
         
             self.editing_medication_id = None


### PR DESCRIPTION
This PR copies name, strength (dosage), directions (route), frequency, and notes (special instructions) from the active medication row onto each administration_log row when a dose is logged so medication history and PDF reports show what was true at dose time instead of whatever the med row says after edits.

- Added extra columns on administration_log in database/db_connection.py (medication name, dosage, route, frequency, special instructions).
- Updated services/administration_log.py so log_medication_taken reads those fields from medications and writes them on the new log row. 
- Updated services/reports.py so get_medication_history pulls those fields from administration_log instead of joining medications.
- Updated inject_test.py so the INSERT matches the new table.
- Added a test in tests/test_administration_log.py that modifies dosage after a dose is logged and checks history still shows the old value

Testing
- For testing, I added a test case mentioned above. To test in the app, you can log the medication taken, edit one of its fields through Manage Medication, and confirm the history log and administration log report shows old values.

Notes
- Requires deleting current medrec.db and recreate
