### PR TITLE
Feature/tracker timing buckets and manual logging

### DIFF
--- a/services/administration_log.py
+++ b/services/administration_log.py
@@ -5,10 +5,12 @@ from datetime import datetime
 from database.db_connection import get_connection
 
 # ADDED BY NC: Log when a medication is taken
-def log_medication_taken(user_id, med_id, conn: sqlite3.Connection | None = None):
-    # Get current date and time
-    date_taken = datetime.now().strftime("%Y-%m-%d")
-    time_taken = datetime.now().strftime("%H:%M:%S")
+def log_medication_taken(user_id, med_id, date_taken=None, time_taken=None, conn: sqlite3.Connection | None = None):
+    # Get current date and time if no datetime provided
+    if date_taken is None:
+        date_taken = datetime.now().strftime("%Y-%m-%d")
+    if time_taken is None:
+        time_taken = datetime.now().strftime("%H:%M:%S")
 
     if conn is None:
         conn = get_connection()

--- a/ui/manage_medication.py
+++ b/ui/manage_medication.py
@@ -23,7 +23,6 @@ _OCR_FREQ_TO_SCHEDULE = {
     "Twice daily":        (1,  2),
     "Three times daily":  (1,  3),
     "Four times daily":   (1,  4),
-    "Every other day":    (2,  1),
     "Weekly":             (7,  1),
     "Once weekly":        (7,  1),
     "Every other day":    (2,  1),
@@ -120,7 +119,7 @@ class ManageMedicationScreen(QWidget):
         self.form.addRow("Directions:", self.input_directions)
         self.form.addRow("Notes:", self.input_notes)
 
-        # ── Frequency row: "Every [N] [day(s)/week(s)], [N] time(s) per dose day" ──
+        # ── Frequency row: "Every [N] [day(s)/week(s)], [N] time(s) per day" ──
         freq_row = QHBoxLayout()
         freq_row.setSpacing(6)
 
@@ -145,7 +144,7 @@ class ManageMedicationScreen(QWidget):
         self.input_doses_per_day.setFixedWidth(55)
         freq_row.addWidget(self.input_doses_per_day)
 
-        freq_row.addWidget(QLabel("time(s) per dose day"))
+        freq_row.addWidget(QLabel("time(s) per day"))
         freq_row.addStretch()
 
         self.form.addRow("Frequency:", freq_row)

--- a/ui/tracking_screen.py
+++ b/ui/tracking_screen.py
@@ -1,9 +1,10 @@
 # UI screen for tracking today's dosages
 
 from datetime import datetime
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QPushButton, QMessageBox
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QPushButton, QMessageBox, \
+    QDialog, QFormLayout, QDateEdit, QTimeEdit,  QDialogButtonBox
 from PyQt6.QtGui import QFont
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QDate, QTime
 from services.medication import get_todays_medications_sorted
 from services.administration_log import log_medication_taken, undo_medication_taken
 
@@ -93,7 +94,6 @@ class DosageTrackingScreen(QWidget):
 
         return buckets, unscheduled
 
-
     def load_medications(self):
         self.tracking_list.clear()
 
@@ -154,6 +154,39 @@ class DosageTrackingScreen(QWidget):
             spacer = QListWidgetItem()
             spacer.setFlags(Qt.ItemFlag.NoItemFlags)
             self.tracking_list.addItem(spacer)
+    
+    def open_log_dose_popup(self):
+        """Opens a popup to pick the log date and time and returns (date, time)"""
+        popup = QDialog(self)
+        popup.setWindowTitle("Log Dose")
+        popup.setMinimumWidth(400)
+        popup_form = QFormLayout(popup)
+
+        # Date row
+        date_input = QDateEdit()
+        date_input.setCalendarPopup(True)
+        date_input.setDate(QDate.currentDate())
+        date_input.setDisplayFormat("yyyy-MM-dd")
+        date_input.setMaximumDate(QDate.currentDate()) # constraint for no future logging
+        popup_form.addRow("Date:", date_input)
+
+        # Time row
+        time_input = QTimeEdit()
+        time_input.setTime(QTime.currentTime())
+        time_input.setDisplayFormat("hh:mm:ss AP")
+        popup_form.addRow("Time:", time_input)
+
+        # Default qt6 buttons to save or exit from popup
+        popup_buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        popup_buttons.accepted.connect(popup.accept)
+        popup_buttons.rejected.connect(popup.reject)
+        popup_form.addRow(popup_buttons)
+
+        # If user exited out of the popup don't save data
+        if popup.exec() != QDialog.DialogCode.Accepted:
+            return None
+
+        return (date_input.date().toString("yyyy-MM-dd"), time_input.time().toString("HH:mm:ss"))
 
     def mark_as_taken(self):
         selected_item = self.tracking_list.currentItem()
@@ -163,13 +196,23 @@ class DosageTrackingScreen(QWidget):
             return
 
         data = selected_item.data(32)
-        if data["times_taken"] >= data["doses_per_day"]:
+        
+        # Open popup when user selects mark as taken
+        dose_time = self.open_log_dose_popup()
+        
+        # Popup closed
+        if dose_time is None:
+            return
+
+        log_date, log_time = dose_time
+        # Only enforce max doses rule for medications dated today (since it's based on today's count and not historical values)
+        if data["times_taken"] >= data["doses_per_day"] and log_date == QDate.currentDate().toString("yyyy-MM-dd"):
             label = "dose" if data["doses_per_day"] == 1 else "all doses"
             QMessageBox.information(self, "Already Taken",
                                     f"You have already logged {label} for today.")
             return
 
-        log_medication_taken(self.user_id, data["med_id"])
+        log_medication_taken(self.user_id, data["med_id"], log_date, log_time)
         self.load_medications()
         QMessageBox.information(self, "Success", "Dose logged successfully.")
 

--- a/ui/tracking_screen.py
+++ b/ui/tracking_screen.py
@@ -1,9 +1,9 @@
 # UI screen for tracking today's dosages
 
 from datetime import datetime
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QListWidget, QPushButton, QMessageBox
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QPushButton, QMessageBox
 from PyQt6.QtGui import QFont
-
+from PyQt6.QtCore import Qt
 from services.medication import get_todays_medications_sorted
 from services.administration_log import log_medication_taken, undo_medication_taken
 
@@ -25,6 +25,7 @@ class DosageTrackingScreen(QWidget):
 
         self.user_id = user_id
         self.go_back_callback = go_back_callback
+        self.timing_buckets = ("Morning", "Midday", "Afternoon", "Evening", "Bedtime")
         self.large_font = QFont("Arial", 16)
         self.setFont(self.large_font)
 
@@ -70,6 +71,29 @@ class DosageTrackingScreen(QWidget):
         if self.go_back_callback:
             self.go_back_callback()
 
+    def split_meds_by_timing_bucket(self, meds):
+        """Splits today's meds into timing buckets for display"""
+        # Each bucket name and list of meds under that heading (excluding unstandardized entries)
+        buckets = {name: [] for name in self.timing_buckets}
+        unscheduled = []
+
+        # Put each med into every timing bucket it's assigned to
+        for med in meds:
+            med_id, name, dosage, scheduled_time, doses_per_day, times_taken, notes = med
+
+            has_standard_time = False
+            for time in scheduled_time.split(","):
+                if time in buckets:
+                    buckets[time].append(med)
+                    has_standard_time = True
+
+            # No time selected / old med / test entry
+            if not has_standard_time:
+                unscheduled.append(med)
+
+        return buckets, unscheduled
+
+
     def load_medications(self):
         self.tracking_list.clear()
 
@@ -79,33 +103,57 @@ class DosageTrackingScreen(QWidget):
             self.tracking_list.addItem("No medications scheduled for today.")
             return
 
-        for med in meds:
-            med_id, name, dosage, scheduled_time, doses_per_day, times_taken, notes = med
+        buckets, unscheduled = self.split_meds_by_timing_bucket(meds)
 
-            notes_display = f" | {notes}" if notes else ""
-            all_taken = times_taken >= doses_per_day
-            dose_counter = f" [{times_taken}/{doses_per_day} doses]" if doses_per_day > 1 else ""
+        # Build the headings by time bucket 
+        time_headings = []
+        for time_bucket in self.timing_buckets:
+            if buckets[time_bucket]:
+                time_headings.append((time_bucket, buckets[time_bucket]))
 
-            if all_taken:
-                display_text = (
-                    f"{scheduled_time} — {name} ({dosage}){notes_display}{dose_counter} ✅"
+        # For meds without a standardized time entry
+        if unscheduled:
+            time_headings.append(("Unscheduled", unscheduled))
+
+        # Create the heading items for each time bucket
+        for time_header, meds_in_heading in time_headings:
+            time_heading_item = QListWidgetItem(time_header)
+            time_heading_item.setFlags(Qt.ItemFlag.NoItemFlags)
+            time_heading_item.setFont(QFont("Arial", 16, QFont.Weight.Bold))
+            self.tracking_list.addItem(time_heading_item)
+    
+            for med in meds_in_heading:
+                med_id, name, dosage, scheduled_time, doses_per_day, times_taken, notes = med
+
+                notes_display = f" | {notes}" if notes else ""
+                all_taken = times_taken >= doses_per_day
+                dose_counter = f" [{times_taken}/{doses_per_day} doses]" if doses_per_day > 1 else ""
+
+                if all_taken:
+                    display_text = (
+                        f"{name} ({dosage}){notes_display}{dose_counter} ✅"
+                    )
+                else:
+                    display_text = (
+                        f"{name} ({dosage}){notes_display}{dose_counter}"
+                    )
+
+                self.tracking_list.addItem(display_text)
+
+                # Store scheduling data so the action buttons know what to act on
+                self.tracking_list.item(self.tracking_list.count() - 1).setData(
+                    32,
+                    {
+                        "med_id":        med_id,
+                        "doses_per_day": doses_per_day,
+                        "times_taken":   times_taken,
+                    },
                 )
-            else:
-                display_text = (
-                    f"{scheduled_time} — {name} ({dosage}){notes_display}{dose_counter}"
-                )
 
-            self.tracking_list.addItem(display_text)
-
-            # Store scheduling data so the action buttons know what to act on
-            self.tracking_list.item(self.tracking_list.count() - 1).setData(
-                32,
-                {
-                    "med_id":        med_id,
-                    "doses_per_day": doses_per_day,
-                    "times_taken":   times_taken,
-                },
-            )
+            # Spacer between headings
+            spacer = QListWidgetItem()
+            spacer.setFlags(Qt.ItemFlag.NoItemFlags)
+            self.tracking_list.addItem(spacer)
 
     def mark_as_taken(self):
         selected_item = self.tracking_list.currentItem()


### PR DESCRIPTION
This PR groups the daily tracker list into Morning / Midday / Afternoon / Evening / Bedtime sections (plus Unscheduled for non-bucket timing text) using each med's scheduled_time CSV. Adds a "Log Dose" dialog (open_log_dose_popup) when Mark Selected as Taken is used so the user can pick a log date/time (defaults to now) with future dates blocked. Backdated logs skip the "already taken for today" cap because that check is based on today’s dose count and not older days.

- Updated ui/tracking_screen.py to split meds into timing buckets for display, render timing headers and med rows, and open the log popup from mark_as_taken.
- Updated services/administration_log.py so log_medication_taken can take optional date_taken / time_taken strings and still defaults to "now" when they aren’t passed.

Testing
- Confirmed pytest suite passing locally. To test changes in the app: confirm meds land under the right headings, Unscheduled works for odd scheduled_time strings, logging for today still enforces the daily limit when appropriate, and backdated logs write to history and show in report with the chosen date/time (24-hour format stored in the DB but the time picker shows AM/PM in the UI).

Notes
- Known limitation: Undo still only removes today's most recent log entry (same as before).